### PR TITLE
Categories on need create

### DIFF
--- a/app/graphql/mutations/create_need.rb
+++ b/app/graphql/mutations/create_need.rb
@@ -9,11 +9,12 @@ class Mutations::CreateNeed < Mutations::BaseMutation
   argument :state, String, required: false
   argument :zip_code, String, required: true
   argument :supporters_needed, Integer, required: true
+  argument :categories, [ID], required: false
 
   field :need, Types::NeedType, null: true
   field :errors, [String], null: false
 
-  def resolve(title:, point_of_contact:, description:, start_time:, end_time:, street_address: nil, city: nil, state: nil, zip_code:, supporters_needed:)
+  def resolve(title:, point_of_contact:, description:, start_time:, end_time:, street_address: nil, city: nil, state: nil, zip_code:, supporters_needed:, categories:[])
     need = Need.new(
             title: title,
             point_of_contact: point_of_contact,
@@ -29,6 +30,10 @@ class Mutations::CreateNeed < Mutations::BaseMutation
             )
 
     if need.save
+      categories.each do |category_id|
+        NeedCategory.create(need_id: need.id, category_id: category_id)
+      end
+
       {
         need: need,
         errors: []

--- a/spec/graphql/mutations/needs/create_need_spec.rb
+++ b/spec/graphql/mutations/needs/create_need_spec.rb
@@ -3,6 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Create a new need', type: :request do
   describe 'happy path' do
     before :each do
+      @cat_1 = Category.create!(tag: "Food")
+      @cat_2 = Category.create!(tag: "Manual Labor")
+      @cat_3 = Category.create!(tag: "Cleanup")
+
       @query =
               <<~GQL
                 mutation {
@@ -17,6 +21,7 @@ RSpec.describe 'Create a new need', type: :request do
                     state: "Colorado"
                     zipCode: "80218"
                     supportersNeeded: 15
+                    categories: [#{@cat_1.id}, #{@cat_3.id}]
                   }
                   )
                   {
@@ -44,6 +49,9 @@ RSpec.describe 'Create a new need', type: :request do
       expect(Need.last.supporters_needed).to eq(15)
       expect(Need.last.title).to eq("Cleanup our park")
       expect(Need.last.street_address).to eq(nil)
+      expect(Need.last.categories.length).to eq(2)
+      expect(Need.last.categories.first.id).to eq(@cat_1.id)
+      expect(Need.last.categories.last.id).to eq(@cat_3.id)
     end
 
     it 'sets status to active in create' do
@@ -55,6 +63,10 @@ RSpec.describe 'Create a new need', type: :request do
 
   describe 'sad path' do
     before :each do
+      @cat_1 = Category.create!(tag: "Food")
+      @cat_2 = Category.create!(tag: "Manual Labor")
+      @cat_3 = Category.create!(tag: "Cleanup")
+
       @incomplete_query =
               <<~GQL
                 mutation {
@@ -67,6 +79,7 @@ RSpec.describe 'Create a new need', type: :request do
                     state: "Colorado"
                     zipCode: "80218"
                     supportersNeeded: 15
+                    categories: [#{@cat_1.id}, #{@cat_3.id}]
                   }
                   )
                   {

--- a/spec/graphql/queries/categories/get_categories_spec.rb
+++ b/spec/graphql/queries/categories/get_categories_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'get all categories', type: :request do
+  describe 'find list of categories' do
+    describe 'allCategories' do
+      it 'can return all information' do
+        category_1 = Category.create( tag: "moving")
+        category_2 = Category.create(tag: "food preparation")
+        category_3 = Category.create(tag: "organizing events")
+
+        query = <<~GQL
+                { allCategories
+                  {
+                    tag
+                  }
+                }
+                GQL
+
+        post '/graphql', params: {query: query}
+
+        needs = JSON.parse(response.body, symbolize_names: true)
+
+        expect(response).to be_successful
+        expect(response.status).to eq(200)
+        expect(response.content_type).to eq("application/json")
+
+        expect(needs[:data][:allCategories]).to be_a(Array)
+        expect(needs[:data][:allCategories].count).to eq(3)
+
+        expect(needs[:data][:allCategories].first).to have_key(:tag)
+        expect(needs[:data][:allCategories].first[:tag]).to eq("moving")
+
+        expect(needs[:data][:allCategories].last).to have_key(:tag)
+        expect(needs[:data][:allCategories].last[:tag]).to eq("organizing events")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes
* Update `create_need` mutation to take in an array of category IDs and create the `NeedCategory` record upon saving a new Need
*  Update `create_need` spec to test for category intake and creation
* Add tests Andrew wrote previously for getAllCategories - should have already been in main but was not showing on my pull. Wondering if this was a loss in the hard pull I did earlier to realign local and remote

## Checklist
- [x] Commits rebased and merge conflicts resolved
- [x] Tests written where required
- [x] All tests passing
- [95%] SimpleCov at 100%

closes #15 
